### PR TITLE
Fix frontmatter bug

### DIFF
--- a/tbdoc/bin/utils.js
+++ b/tbdoc/bin/utils.js
@@ -9,6 +9,25 @@ import path from 'path'
 import glob from 'glob'
 
 /**
+ * Synchronously copy files, creating directories if they do not exist.
+ * @param {string} filepath
+ * @param {string} content
+ */
+ function copyFileSyncRecursive(src, dest) {
+  fs.mkdirSync(path.dirname(dest), {recursive: true})
+  fs.copyFileSync(src, dest)
+}
+
+/**
+ * Find all images sub-directories.
+ * @param {string} input_dir
+ * @returns {string[]}
+ */
+ function findImages(dir) {
+  return glob.sync(dir + '/**/images/*')
+}
+
+/**
  * Find all documentation Markdown (.md) files in a directory.
  * @param {string} input_dir
  * @returns {string[]}
@@ -19,7 +38,7 @@ function findMarkdownDocs(dir) {
 
 /**
  * Reads in from a filepath and creates a vfile.
- * @param {string} filename 
+ * @param {string} filename
  * @returns {Promise<VFile>}
  */
 async function readFile(filepath) {
@@ -28,7 +47,7 @@ async function readFile(filepath) {
 
 /**
  * Transforms Markdown VFile using specified plugins.
- * @param {VFile} doc 
+ * @param {VFile} doc
  * @returns {Promise<VFile>}
  */
 function transform(doc) {
@@ -50,4 +69,4 @@ function writeFileSyncRecursive(filepath, content) {
   fs.writeFileSync(filepath, content, 'utf-8')
 }
 
-export { findMarkdownDocs, readFile, transform, writeFileSyncRecursive }
+export default { copyFileSyncRecursive, findImages, findMarkdownDocs, readFile, transform, writeFileSyncRecursive }

--- a/tbdoc/bin/utils.js
+++ b/tbdoc/bin/utils.js
@@ -3,6 +3,7 @@ import {read} from 'to-vfile'
 import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
 import remarkStringify from 'remark-stringify'
+import remarkFrontmatter from 'remark-frontmatter'
 import { codeImport } from 'remark-code-import'
 import fs from 'fs'
 import path from 'path'
@@ -56,6 +57,7 @@ function transform(doc) {
   .use(remarkGfm)
   .use(codeImport)
   .use(remarkStringify)
+  .use(remarkFrontmatter)
   .process(doc)
 }
 

--- a/tbdoc/package-lock.json
+++ b/tbdoc/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "glob": "^8.0.3",
         "remark-code-import": "^1.1.1",
+        "remark-frontmatter": "^4.0.1",
         "remark-gfm": "^3.0.1",
         "remark-parse": "^10.0.1",
         "remark-stringify": "^10.0.2",
@@ -212,6 +213,26 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -355,6 +376,18 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.0.tgz",
+      "integrity": "sha512-7itKvp0arEVNpCktOET/eLFAYaZ+0cNjVtFtIPxgQ5tV+3i+D4SDDTjTzPWl44LT59PC+xdx+glNTawBdF98Mw==",
+      "dependencies": {
+        "micromark-extension-frontmatter": "^1.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -540,6 +573,20 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.0.0.tgz",
+      "integrity": "sha512-EXjmRnupoX6yYuUJSQhrQ9ggK0iQtQlpi6xeJzVD5xscyAI+giqco5fdymayZhJMbIFecjnE2yz85S9NzIgQpg==",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -1065,6 +1112,21 @@
         "node": ">= 12"
       }
     },
+    "node_modules/remark-frontmatter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
+      "integrity": "sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-frontmatter": "^1.0.0",
+        "micromark-extension-frontmatter": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
@@ -1560,6 +1622,19 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "requires": {
+        "format": "^0.2.0"
+      }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1653,6 +1728,14 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
+      }
+    },
+    "mdast-util-frontmatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.0.tgz",
+      "integrity": "sha512-7itKvp0arEVNpCktOET/eLFAYaZ+0cNjVtFtIPxgQ5tV+3i+D4SDDTjTzPWl44LT59PC+xdx+glNTawBdF98Mw==",
+      "requires": {
+        "micromark-extension-frontmatter": "^1.0.0"
       }
     },
     "mdast-util-gfm": {
@@ -1782,6 +1865,16 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-frontmatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.0.0.tgz",
+      "integrity": "sha512-EXjmRnupoX6yYuUJSQhrQ9ggK0iQtQlpi6xeJzVD5xscyAI+giqco5fdymayZhJMbIFecjnE2yz85S9NzIgQpg==",
+      "requires": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
       }
     },
     "micromark-extension-gfm": {
@@ -2075,6 +2168,17 @@
         "strip-indent": "^4.0.0",
         "to-gatsby-remark-plugin": "^0.1.0",
         "unist-util-visit": "^4.1.0"
+      }
+    },
+    "remark-frontmatter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
+      "integrity": "sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-frontmatter": "^1.0.0",
+        "micromark-extension-frontmatter": "^1.0.0",
+        "unified": "^10.0.0"
       }
     },
     "remark-gfm": {

--- a/tbdoc/package.json
+++ b/tbdoc/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "glob": "^8.0.3",
     "remark-code-import": "^1.1.1",
+    "remark-frontmatter": "^4.0.1",
     "remark-gfm": "^3.0.1",
     "remark-parse": "^10.0.1",
     "remark-stringify": "^10.0.2",


### PR DESCRIPTION
Prior to this fix, when Markdown files were parsed, transformed, and serialized by remark the front matter metadata delimiters were garbled. Before the fix, the following front matter

```yaml
---
id: getting-started-with-tbds-ssi-service
title: Getting Started with TBD's SSI Service
---
```

would have been transformed to:

```yaml
***
id: getting-started-with-tbds-ssi-service
title: Getting Started with TBD's SSI Service
---
```

Now the first set of hyphens (`---`) are not modified post-processing.