### PR TITLE
Revert the tbdoc executable Docker container to use the /app dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ To process all Markdown (.md) files in your local `docs` directory and output th
 Markdown and associated images to your local `build` directory:
 
 ```sh
-docker run --rm -v "$PWD/docs":/home/node/app/docs -v "$PWD/build":/home/node/app/build tbdoc:1.0.0
+docker run --rm -v "$PWD/docs":/app/docs -v "$PWD/build":/app/build tbdoc:1.0.0
 ```
 
 Another example to demonstrate changing the source files directory to `input` and the
 directory to store transformed documents to `output`:
 
 ```sh
-docker run --rm -v "$PWD/input":/home/node/app/docs -v "$PWD/output":/app/build tbdoc:1.0.0
+docker run --rm -v "$PWD/input":/app/docs -v "$PWD/output":/app/build tbdoc:1.0.0
 ```

--- a/tbdoc/Dockerfile
+++ b/tbdoc/Dockerfile
@@ -1,12 +1,9 @@
 FROM node:16-alpine
 
 # Define variables
-ARG APP_DIR="/home/node/app"
+ARG APP_DIR="/app"
 
-# Switch to the `node` user vs. root
-# USER node
-
-# Install and run the app from the `node` user's home directory
+# Install and run the app from the specified directory
 RUN mkdir ${APP_DIR}
 WORKDIR ${APP_DIR}
 
@@ -16,11 +13,7 @@ RUN npm install
 
 # Copy and link Node.js package
 COPY ./bin ${APP_DIR}/bin
-
-# Switch to root temporarily to link the package to the global node_modules directory
-# USER root
 RUN npm link
-# USER node
 
 # Specify a mount point in the container that will be mapped to a directory
 # on the host when the container is started.


### PR DESCRIPTION
Permissions errors are encountered when running the tbdoc utility as a non-root user on GitHub Action runners. To enable this utility to process Markdown files for both local development and during GitHub Actions workflows, commands must be run under the root user.  To avoid the misperception that Node.js packages under /home/node/app are run by a non-root user, the container will be reverted to storing packages under /app.